### PR TITLE
Fix achievements heading

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,7 @@ const navLinks = [
   { id: 'home',         label: 'Home' },
   { id: 'skills',       label: 'Skills' },
   { id: 'projects',     label: 'Experience' },
-  { id: 'publications', label: 'Achivements' },
+  { id: 'publications', label: 'Achievements' },
   { id: 'contact',      label: 'Contact' },
 ];
 

--- a/src/components/PublicationsSection.tsx
+++ b/src/components/PublicationsSection.tsx
@@ -54,7 +54,7 @@ const PublicationsSection = () => {
   return (
     <section id="publications" className="section-padding bg-dark bg-subtle-grid">
       <div className="container mx-auto px-4">
-        <h2 className="section-title text-center">My <span style={{ color: '#CBACF9' }}>Achivements</span></h2>
+        <h2 className="section-title text-center">My <span style={{ color: '#CBACF9' }}>Achievements</span></h2>
         
         <div className="flex flex-wrap justify-center gap-2 mb-10">
           {publicationTypes.map(type => (


### PR DESCRIPTION
## Summary
- restore "My Achievements" heading with correct spelling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683febabce88833094a88f508040b947